### PR TITLE
No large token count warning message when using no-clipboard

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -294,8 +294,10 @@ async fn main() -> Result<(), Error> {
     };
 
     // Add token count warning if needed
-    if let Some(warning) = validate_token_count(tokens) {
-        warnings.push(warning);
+    if !args.no_clipboard {
+        if let Some(warning) = validate_token_count(tokens) {
+            warnings.push(warning);
+        }
     }
 
     let paths: Vec<String> = files


### PR DESCRIPTION
Fix #29 